### PR TITLE
Adds ability to move windows list to the end of the context menu.

### DIFF
--- a/PinWin/App.config
+++ b/PinWin/App.config
@@ -19,6 +19,9 @@
             <setting name="TitleLengthLimit" serializeAs="String">
                 <value>50</value>
             </setting>
+            <setting name="WindowsListAtEnd" serializeAs="String">
+                <value>False</value>
+            </setting>
         </PinWin.Properties.Settings>
     </userSettings>
 </configuration>

--- a/PinWin/MainApplicationContext.cs
+++ b/PinWin/MainApplicationContext.cs
@@ -6,6 +6,7 @@ using PinWin.Properties;
 using Bluegrams.Windows.Tools;
 using Bluegrams.Application.WinForms;
 using Bluegrams.Application;
+using System.Collections.Generic;
 
 namespace PinWin
 {
@@ -71,27 +72,44 @@ namespace PinWin
             }
         }
 
-        private void ContextMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
-        {
-            ContextMenu.Items.Clear();
-            foreach (var kv in WinApi.GetWindowHandles())
-            {
-                bool topmost = WinApi.GetWindowTopmost(kv.Key);
-                string truncated = kv.Value.Substring(0, Math.Min(kv.Value.Length, Settings.Default.TitleLengthLimit));
-                ContextMenu.Items.Add(new ToolStripMenuItem(truncated, null, 
-                    (o, args) => WinApi.SetWindowTopmost(kv.Key, !topmost))
-                {
-                    Checked = topmost,
-                    ToolTipText = kv.Value
-                });
+		private void ContextMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+		{
+			ContextMenu.Items.Clear();
 
-            }
-            ContextMenu.Items.Add(new ToolStripSeparator());
-            ContextMenu.Items.Add("Select Window From Screen", Resources.TargetIcon, onSelectWindowClicked);
-            ContextMenu.Items.Add("Unpin All Windows", Resources.DeleteIcon, onUnpinAllClicked);
-            ContextMenu.Items.Add("Options", Resources.OptionsIcon, onOptionsClicked);
-            ContextMenu.Items.Add("About", Resources.AboutIcon, onAboutClicked);
-            ContextMenu.Items.Add("Exit", null, onExitClicked);
+			var windowsItems = new List<ToolStripMenuItem>();
+			foreach (var kv in WinApi.GetWindowHandles())
+			{
+				bool topmost = WinApi.GetWindowTopmost(kv.Key);
+				string truncated = kv.Value.Substring(0, Math.Min(kv.Value.Length, Settings.Default.TitleLengthLimit));
+				windowsItems.Add(new ToolStripMenuItem(truncated, null,
+					(o, args) => WinApi.SetWindowTopmost(kv.Key, !topmost))
+				{
+					Checked = topmost,
+					ToolTipText = kv.Value
+				});
+			};
+
+			var generalItems = new List<ToolStripMenuItem>()
+			{
+				new ToolStripMenuItem("Select Window From Screen", Resources.TargetIcon, onSelectWindowClicked),
+				new ToolStripMenuItem("Unpin All Windows", Resources.DeleteIcon, onUnpinAllClicked),
+				new ToolStripMenuItem("Options", Resources.OptionsIcon, onOptionsClicked),
+				new ToolStripMenuItem("About", Resources.AboutIcon, onAboutClicked),
+				new ToolStripMenuItem("Exit", null, onExitClicked),
+			};
+
+			if (Settings.Default.WindowsListAtEnd)
+			{
+				ContextMenu.Items.AddRange(generalItems.ToArray());
+				ContextMenu.Items.Add(new ToolStripSeparator());
+				ContextMenu.Items.AddRange(windowsItems.ToArray());
+			} else
+			{
+				ContextMenu.Items.AddRange(windowsItems.ToArray());
+				ContextMenu.Items.Add(new ToolStripSeparator());
+				ContextMenu.Items.AddRange(generalItems.ToArray());
+			}
+
             e.Cancel = false;
         }
 

--- a/PinWin/MainApplicationContext.cs
+++ b/PinWin/MainApplicationContext.cs
@@ -2,11 +2,11 @@
 using System.Reflection;
 using System.Windows.Forms;
 using System.Drawing;
+using System.Collections.Generic;
 using PinWin.Properties;
 using Bluegrams.Windows.Tools;
 using Bluegrams.Application.WinForms;
 using Bluegrams.Application;
-using System.Collections.Generic;
 
 namespace PinWin
 {
@@ -72,43 +72,44 @@ namespace PinWin
             }
         }
 
-		private void ContextMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
-		{
-			ContextMenu.Items.Clear();
+        private void ContextMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            ContextMenu.Items.Clear();
 
-			var windowsItems = new List<ToolStripMenuItem>();
-			foreach (var kv in WinApi.GetWindowHandles())
-			{
-				bool topmost = WinApi.GetWindowTopmost(kv.Key);
-				string truncated = kv.Value.Substring(0, Math.Min(kv.Value.Length, Settings.Default.TitleLengthLimit));
-				windowsItems.Add(new ToolStripMenuItem(truncated, null,
-					(o, args) => WinApi.SetWindowTopmost(kv.Key, !topmost))
-				{
-					Checked = topmost,
-					ToolTipText = kv.Value
-				});
-			};
+            var windowsItems = new List<ToolStripMenuItem>();
+            foreach (var kv in WinApi.GetWindowHandles())
+            {
+                bool topmost = WinApi.GetWindowTopmost(kv.Key);
+                string truncated = kv.Value.Substring(0, Math.Min(kv.Value.Length, Settings.Default.TitleLengthLimit));
+                windowsItems.Add(new ToolStripMenuItem(truncated, null,
+                    (o, args) => WinApi.SetWindowTopmost(kv.Key, !topmost))
+                {
+                    Checked = topmost,
+                    ToolTipText = kv.Value
+                });
+            };
 
-			var generalItems = new List<ToolStripMenuItem>()
-			{
-				new ToolStripMenuItem("Select Window From Screen", Resources.TargetIcon, onSelectWindowClicked),
-				new ToolStripMenuItem("Unpin All Windows", Resources.DeleteIcon, onUnpinAllClicked),
-				new ToolStripMenuItem("Options", Resources.OptionsIcon, onOptionsClicked),
-				new ToolStripMenuItem("About", Resources.AboutIcon, onAboutClicked),
-				new ToolStripMenuItem("Exit", null, onExitClicked),
-			};
+            var generalItems = new List<ToolStripMenuItem>()
+            {
+                new ToolStripMenuItem("Select Window From Screen", Resources.TargetIcon, onSelectWindowClicked),
+                new ToolStripMenuItem("Unpin All Windows", Resources.DeleteIcon, onUnpinAllClicked),
+                new ToolStripMenuItem("Options", Resources.OptionsIcon, onOptionsClicked),
+                new ToolStripMenuItem("About", Resources.AboutIcon, onAboutClicked),
+                new ToolStripMenuItem("Exit", null, onExitClicked),
+            };
 
-			if (Settings.Default.WindowsListAtEnd)
-			{
-				ContextMenu.Items.AddRange(generalItems.ToArray());
-				ContextMenu.Items.Add(new ToolStripSeparator());
-				ContextMenu.Items.AddRange(windowsItems.ToArray());
-			} else
-			{
-				ContextMenu.Items.AddRange(windowsItems.ToArray());
-				ContextMenu.Items.Add(new ToolStripSeparator());
-				ContextMenu.Items.AddRange(generalItems.ToArray());
-			}
+            if (Settings.Default.WindowsListAtEnd)
+            {
+                ContextMenu.Items.AddRange(generalItems.ToArray());
+                ContextMenu.Items.Add(new ToolStripSeparator());
+                ContextMenu.Items.AddRange(windowsItems.ToArray());
+            }
+            else
+            {
+                ContextMenu.Items.AddRange(windowsItems.ToArray());
+                ContextMenu.Items.Add(new ToolStripSeparator());
+                ContextMenu.Items.AddRange(generalItems.ToArray());
+            }
 
             e.Cancel = false;
         }

--- a/PinWin/OptionsForm.Designer.cs
+++ b/PinWin/OptionsForm.Designer.cs
@@ -28,175 +28,188 @@
         /// </summary>
         private void InitializeComponent()
         {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(OptionsForm));
-            this.butCancel = new System.Windows.Forms.Button();
-            this.butSubmit = new System.Windows.Forms.Button();
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.panHotKey = new System.Windows.Forms.Panel();
-            this.butHotKey = new System.Windows.Forms.Button();
-            this.txtHotKey = new System.Windows.Forms.TextBox();
-            this.chkHotKey = new System.Windows.Forms.CheckBox();
-            this.numLimit = new System.Windows.Forms.NumericUpDown();
-            this.chkTruncateTitle = new System.Windows.Forms.CheckBox();
-            this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.chkUpdates = new System.Windows.Forms.CheckBox();
-            this.groupBox1.SuspendLayout();
-            this.panHotKey.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numLimit)).BeginInit();
-            this.groupBox2.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // butCancel
-            // 
-            this.butCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.butCancel.Location = new System.Drawing.Point(287, 170);
-            this.butCancel.Name = "butCancel";
-            this.butCancel.Size = new System.Drawing.Size(85, 25);
-            this.butCancel.TabIndex = 2;
-            this.butCancel.Text = "Cancel";
-            this.butCancel.UseVisualStyleBackColor = true;
-            // 
-            // butSubmit
-            // 
-            this.butSubmit.Location = new System.Drawing.Point(196, 170);
-            this.butSubmit.Name = "butSubmit";
-            this.butSubmit.Size = new System.Drawing.Size(85, 25);
-            this.butSubmit.TabIndex = 1;
-            this.butSubmit.Text = "OK";
-            this.butSubmit.UseVisualStyleBackColor = true;
-            this.butSubmit.Click += new System.EventHandler(this.butSubmit_Click);
-            // 
-            // groupBox1
-            // 
-            this.groupBox1.Controls.Add(this.panHotKey);
-            this.groupBox1.Controls.Add(this.chkHotKey);
-            this.groupBox1.Controls.Add(this.numLimit);
-            this.groupBox1.Controls.Add(this.chkTruncateTitle);
-            this.groupBox1.Location = new System.Drawing.Point(12, 12);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(360, 76);
-            this.groupBox1.TabIndex = 3;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "General";
-            // 
-            // panHotKey
-            // 
-            this.panHotKey.Controls.Add(this.butHotKey);
-            this.panHotKey.Controls.Add(this.txtHotKey);
-            this.panHotKey.Location = new System.Drawing.Point(151, 45);
-            this.panHotKey.Name = "panHotKey";
-            this.panHotKey.Size = new System.Drawing.Size(203, 25);
-            this.panHotKey.TabIndex = 5;
-            // 
-            // butHotKey
-            // 
-            this.butHotKey.Location = new System.Drawing.Point(128, 1);
-            this.butHotKey.Name = "butHotKey";
-            this.butHotKey.Size = new System.Drawing.Size(75, 23);
-            this.butHotKey.TabIndex = 4;
-            this.butHotKey.Text = "Change";
-            this.butHotKey.UseVisualStyleBackColor = true;
-            this.butHotKey.Click += new System.EventHandler(this.butHotKey_Click);
-            // 
-            // txtHotKey
-            // 
-            this.txtHotKey.Location = new System.Drawing.Point(0, 3);
-            this.txtHotKey.Name = "txtHotKey";
-            this.txtHotKey.ReadOnly = true;
-            this.txtHotKey.Size = new System.Drawing.Size(122, 20);
-            this.txtHotKey.TabIndex = 2;
-            // 
-            // chkHotKey
-            // 
-            this.chkHotKey.AutoSize = true;
-            this.chkHotKey.Location = new System.Drawing.Point(6, 50);
-            this.chkHotKey.Name = "chkHotKey";
-            this.chkHotKey.Size = new System.Drawing.Size(123, 17);
-            this.chkHotKey.TabIndex = 3;
-            this.chkHotKey.Text = "Use a global hot key";
-            this.chkHotKey.UseVisualStyleBackColor = true;
-            this.chkHotKey.CheckedChanged += new System.EventHandler(this.chkHotKey_CheckedChanged);
-            // 
-            // numLimit
-            // 
-            this.numLimit.Location = new System.Drawing.Point(151, 19);
-            this.numLimit.Maximum = new decimal(new int[] {
+			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(OptionsForm));
+			this.butCancel = new System.Windows.Forms.Button();
+			this.butSubmit = new System.Windows.Forms.Button();
+			this.groupBox1 = new System.Windows.Forms.GroupBox();
+			this.panHotKey = new System.Windows.Forms.Panel();
+			this.butHotKey = new System.Windows.Forms.Button();
+			this.txtHotKey = new System.Windows.Forms.TextBox();
+			this.chkHotKey = new System.Windows.Forms.CheckBox();
+			this.numLimit = new System.Windows.Forms.NumericUpDown();
+			this.chkTruncateTitle = new System.Windows.Forms.CheckBox();
+			this.groupBox2 = new System.Windows.Forms.GroupBox();
+			this.chkUpdates = new System.Windows.Forms.CheckBox();
+			this.chkWindowsAtEnd = new System.Windows.Forms.CheckBox();
+			this.groupBox1.SuspendLayout();
+			this.panHotKey.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this.numLimit)).BeginInit();
+			this.groupBox2.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// butCancel
+			// 
+			this.butCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+			this.butCancel.Location = new System.Drawing.Point(287, 202);
+			this.butCancel.Name = "butCancel";
+			this.butCancel.Size = new System.Drawing.Size(85, 25);
+			this.butCancel.TabIndex = 2;
+			this.butCancel.Text = "Cancel";
+			this.butCancel.UseVisualStyleBackColor = true;
+			// 
+			// butSubmit
+			// 
+			this.butSubmit.Location = new System.Drawing.Point(196, 202);
+			this.butSubmit.Name = "butSubmit";
+			this.butSubmit.Size = new System.Drawing.Size(85, 25);
+			this.butSubmit.TabIndex = 1;
+			this.butSubmit.Text = "OK";
+			this.butSubmit.UseVisualStyleBackColor = true;
+			this.butSubmit.Click += new System.EventHandler(this.butSubmit_Click);
+			// 
+			// groupBox1
+			// 
+			this.groupBox1.Controls.Add(this.panHotKey);
+			this.groupBox1.Controls.Add(this.chkHotKey);
+			this.groupBox1.Controls.Add(this.numLimit);
+			this.groupBox1.Controls.Add(this.chkWindowsAtEnd);
+			this.groupBox1.Controls.Add(this.chkTruncateTitle);
+			this.groupBox1.Location = new System.Drawing.Point(12, 12);
+			this.groupBox1.Name = "groupBox1";
+			this.groupBox1.Size = new System.Drawing.Size(360, 109);
+			this.groupBox1.TabIndex = 3;
+			this.groupBox1.TabStop = false;
+			this.groupBox1.Text = "General";
+			// 
+			// panHotKey
+			// 
+			this.panHotKey.Controls.Add(this.butHotKey);
+			this.panHotKey.Controls.Add(this.txtHotKey);
+			this.panHotKey.Location = new System.Drawing.Point(151, 45);
+			this.panHotKey.Name = "panHotKey";
+			this.panHotKey.Size = new System.Drawing.Size(203, 25);
+			this.panHotKey.TabIndex = 5;
+			// 
+			// butHotKey
+			// 
+			this.butHotKey.Location = new System.Drawing.Point(128, 1);
+			this.butHotKey.Name = "butHotKey";
+			this.butHotKey.Size = new System.Drawing.Size(75, 23);
+			this.butHotKey.TabIndex = 4;
+			this.butHotKey.Text = "Change";
+			this.butHotKey.UseVisualStyleBackColor = true;
+			this.butHotKey.Click += new System.EventHandler(this.butHotKey_Click);
+			// 
+			// txtHotKey
+			// 
+			this.txtHotKey.Location = new System.Drawing.Point(0, 3);
+			this.txtHotKey.Name = "txtHotKey";
+			this.txtHotKey.ReadOnly = true;
+			this.txtHotKey.Size = new System.Drawing.Size(122, 20);
+			this.txtHotKey.TabIndex = 2;
+			// 
+			// chkHotKey
+			// 
+			this.chkHotKey.AutoSize = true;
+			this.chkHotKey.Location = new System.Drawing.Point(6, 50);
+			this.chkHotKey.Name = "chkHotKey";
+			this.chkHotKey.Size = new System.Drawing.Size(123, 17);
+			this.chkHotKey.TabIndex = 3;
+			this.chkHotKey.Text = "Use a global hot key";
+			this.chkHotKey.UseVisualStyleBackColor = true;
+			this.chkHotKey.CheckedChanged += new System.EventHandler(this.chkHotKey_CheckedChanged);
+			// 
+			// numLimit
+			// 
+			this.numLimit.Location = new System.Drawing.Point(151, 19);
+			this.numLimit.Maximum = new decimal(new int[] {
             200,
             0,
             0,
             0});
-            this.numLimit.Minimum = new decimal(new int[] {
+			this.numLimit.Minimum = new decimal(new int[] {
             10,
             0,
             0,
             0});
-            this.numLimit.Name = "numLimit";
-            this.numLimit.Size = new System.Drawing.Size(90, 20);
-            this.numLimit.TabIndex = 1;
-            this.numLimit.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-            this.numLimit.Value = new decimal(new int[] {
+			this.numLimit.Name = "numLimit";
+			this.numLimit.Size = new System.Drawing.Size(90, 20);
+			this.numLimit.TabIndex = 1;
+			this.numLimit.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+			this.numLimit.Value = new decimal(new int[] {
             50,
             0,
             0,
             0});
-            // 
-            // chkTruncateTitle
-            // 
-            this.chkTruncateTitle.AutoSize = true;
-            this.chkTruncateTitle.Location = new System.Drawing.Point(6, 20);
-            this.chkTruncateTitle.Name = "chkTruncateTitle";
-            this.chkTruncateTitle.Size = new System.Drawing.Size(132, 17);
-            this.chkTruncateTitle.TabIndex = 0;
-            this.chkTruncateTitle.Text = "Truncate window titles";
-            this.chkTruncateTitle.UseVisualStyleBackColor = true;
-            this.chkTruncateTitle.CheckedChanged += new System.EventHandler(this.chkTruncateTitle_CheckedChanged);
-            // 
-            // groupBox2
-            // 
-            this.groupBox2.Controls.Add(this.chkUpdates);
-            this.groupBox2.Location = new System.Drawing.Point(12, 94);
-            this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(360, 70);
-            this.groupBox2.TabIndex = 4;
-            this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "Application";
-            // 
-            // chkUpdates
-            // 
-            this.chkUpdates.AutoSize = true;
-            this.chkUpdates.Location = new System.Drawing.Point(6, 19);
-            this.chkUpdates.Name = "chkUpdates";
-            this.chkUpdates.Size = new System.Drawing.Size(195, 17);
-            this.chkUpdates.TabIndex = 1;
-            this.chkUpdates.Text = "Always check for updates at startup";
-            this.chkUpdates.UseVisualStyleBackColor = true;
-            // 
-            // OptionsForm
-            // 
-            this.AcceptButton = this.butSubmit;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.CancelButton = this.butCancel;
-            this.ClientSize = new System.Drawing.Size(384, 206);
-            this.Controls.Add(this.groupBox2);
-            this.Controls.Add(this.groupBox1);
-            this.Controls.Add(this.butSubmit);
-            this.Controls.Add(this.butCancel);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "OptionsForm";
-            this.Text = "PinWin - Options";
-            this.TopMost = true;
-            this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
-            this.panHotKey.ResumeLayout(false);
-            this.panHotKey.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numLimit)).EndInit();
-            this.groupBox2.ResumeLayout(false);
-            this.groupBox2.PerformLayout();
-            this.ResumeLayout(false);
+			// 
+			// chkTruncateTitle
+			// 
+			this.chkTruncateTitle.AutoSize = true;
+			this.chkTruncateTitle.Location = new System.Drawing.Point(6, 20);
+			this.chkTruncateTitle.Name = "chkTruncateTitle";
+			this.chkTruncateTitle.Size = new System.Drawing.Size(132, 17);
+			this.chkTruncateTitle.TabIndex = 0;
+			this.chkTruncateTitle.Text = "Truncate window titles";
+			this.chkTruncateTitle.UseVisualStyleBackColor = true;
+			this.chkTruncateTitle.CheckedChanged += new System.EventHandler(this.chkTruncateTitle_CheckedChanged);
+			// 
+			// groupBox2
+			// 
+			this.groupBox2.Controls.Add(this.chkUpdates);
+			this.groupBox2.Location = new System.Drawing.Point(12, 126);
+			this.groupBox2.Name = "groupBox2";
+			this.groupBox2.Size = new System.Drawing.Size(360, 70);
+			this.groupBox2.TabIndex = 4;
+			this.groupBox2.TabStop = false;
+			this.groupBox2.Text = "Application";
+			// 
+			// chkUpdates
+			// 
+			this.chkUpdates.AutoSize = true;
+			this.chkUpdates.Location = new System.Drawing.Point(6, 19);
+			this.chkUpdates.Name = "chkUpdates";
+			this.chkUpdates.Size = new System.Drawing.Size(195, 17);
+			this.chkUpdates.TabIndex = 1;
+			this.chkUpdates.Text = "Always check for updates at startup";
+			this.chkUpdates.UseVisualStyleBackColor = true;
+			// 
+			// chkWindowsAtEnd
+			// 
+			this.chkWindowsAtEnd.AutoSize = true;
+			this.chkWindowsAtEnd.Location = new System.Drawing.Point(6, 80);
+			this.chkWindowsAtEnd.Name = "chkWindowsAtEnd";
+			this.chkWindowsAtEnd.Size = new System.Drawing.Size(163, 17);
+			this.chkWindowsAtEnd.TabIndex = 0;
+			this.chkWindowsAtEnd.Text = "Show windows list at the end";
+			this.chkWindowsAtEnd.UseVisualStyleBackColor = true;
+			this.chkWindowsAtEnd.CheckedChanged += new System.EventHandler(this.chkTruncateTitle_CheckedChanged);
+			// 
+			// OptionsForm
+			// 
+			this.AcceptButton = this.butSubmit;
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.CancelButton = this.butCancel;
+			this.ClientSize = new System.Drawing.Size(384, 239);
+			this.Controls.Add(this.groupBox2);
+			this.Controls.Add(this.groupBox1);
+			this.Controls.Add(this.butSubmit);
+			this.Controls.Add(this.butCancel);
+			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+			this.MaximizeBox = false;
+			this.MinimizeBox = false;
+			this.Name = "OptionsForm";
+			this.Text = "PinWin - Options";
+			this.TopMost = true;
+			this.groupBox1.ResumeLayout(false);
+			this.groupBox1.PerformLayout();
+			this.panHotKey.ResumeLayout(false);
+			this.panHotKey.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this.numLimit)).EndInit();
+			this.groupBox2.ResumeLayout(false);
+			this.groupBox2.PerformLayout();
+			this.ResumeLayout(false);
 
         }
 
@@ -212,5 +225,6 @@
         private System.Windows.Forms.CheckBox chkHotKey;
         private System.Windows.Forms.NumericUpDown numLimit;
         private System.Windows.Forms.CheckBox chkUpdates;
-    }
+		private System.Windows.Forms.CheckBox chkWindowsAtEnd;
+	}
 }

--- a/PinWin/OptionsForm.Designer.cs
+++ b/PinWin/OptionsForm.Designer.cs
@@ -28,188 +28,188 @@
         /// </summary>
         private void InitializeComponent()
         {
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(OptionsForm));
-			this.butCancel = new System.Windows.Forms.Button();
-			this.butSubmit = new System.Windows.Forms.Button();
-			this.groupBox1 = new System.Windows.Forms.GroupBox();
-			this.panHotKey = new System.Windows.Forms.Panel();
-			this.butHotKey = new System.Windows.Forms.Button();
-			this.txtHotKey = new System.Windows.Forms.TextBox();
-			this.chkHotKey = new System.Windows.Forms.CheckBox();
-			this.numLimit = new System.Windows.Forms.NumericUpDown();
-			this.chkTruncateTitle = new System.Windows.Forms.CheckBox();
-			this.groupBox2 = new System.Windows.Forms.GroupBox();
-			this.chkUpdates = new System.Windows.Forms.CheckBox();
-			this.chkWindowsAtEnd = new System.Windows.Forms.CheckBox();
-			this.groupBox1.SuspendLayout();
-			this.panHotKey.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.numLimit)).BeginInit();
-			this.groupBox2.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// butCancel
-			// 
-			this.butCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.butCancel.Location = new System.Drawing.Point(287, 202);
-			this.butCancel.Name = "butCancel";
-			this.butCancel.Size = new System.Drawing.Size(85, 25);
-			this.butCancel.TabIndex = 2;
-			this.butCancel.Text = "Cancel";
-			this.butCancel.UseVisualStyleBackColor = true;
-			// 
-			// butSubmit
-			// 
-			this.butSubmit.Location = new System.Drawing.Point(196, 202);
-			this.butSubmit.Name = "butSubmit";
-			this.butSubmit.Size = new System.Drawing.Size(85, 25);
-			this.butSubmit.TabIndex = 1;
-			this.butSubmit.Text = "OK";
-			this.butSubmit.UseVisualStyleBackColor = true;
-			this.butSubmit.Click += new System.EventHandler(this.butSubmit_Click);
-			// 
-			// groupBox1
-			// 
-			this.groupBox1.Controls.Add(this.panHotKey);
-			this.groupBox1.Controls.Add(this.chkHotKey);
-			this.groupBox1.Controls.Add(this.numLimit);
-			this.groupBox1.Controls.Add(this.chkWindowsAtEnd);
-			this.groupBox1.Controls.Add(this.chkTruncateTitle);
-			this.groupBox1.Location = new System.Drawing.Point(12, 12);
-			this.groupBox1.Name = "groupBox1";
-			this.groupBox1.Size = new System.Drawing.Size(360, 109);
-			this.groupBox1.TabIndex = 3;
-			this.groupBox1.TabStop = false;
-			this.groupBox1.Text = "General";
-			// 
-			// panHotKey
-			// 
-			this.panHotKey.Controls.Add(this.butHotKey);
-			this.panHotKey.Controls.Add(this.txtHotKey);
-			this.panHotKey.Location = new System.Drawing.Point(151, 45);
-			this.panHotKey.Name = "panHotKey";
-			this.panHotKey.Size = new System.Drawing.Size(203, 25);
-			this.panHotKey.TabIndex = 5;
-			// 
-			// butHotKey
-			// 
-			this.butHotKey.Location = new System.Drawing.Point(128, 1);
-			this.butHotKey.Name = "butHotKey";
-			this.butHotKey.Size = new System.Drawing.Size(75, 23);
-			this.butHotKey.TabIndex = 4;
-			this.butHotKey.Text = "Change";
-			this.butHotKey.UseVisualStyleBackColor = true;
-			this.butHotKey.Click += new System.EventHandler(this.butHotKey_Click);
-			// 
-			// txtHotKey
-			// 
-			this.txtHotKey.Location = new System.Drawing.Point(0, 3);
-			this.txtHotKey.Name = "txtHotKey";
-			this.txtHotKey.ReadOnly = true;
-			this.txtHotKey.Size = new System.Drawing.Size(122, 20);
-			this.txtHotKey.TabIndex = 2;
-			// 
-			// chkHotKey
-			// 
-			this.chkHotKey.AutoSize = true;
-			this.chkHotKey.Location = new System.Drawing.Point(6, 50);
-			this.chkHotKey.Name = "chkHotKey";
-			this.chkHotKey.Size = new System.Drawing.Size(123, 17);
-			this.chkHotKey.TabIndex = 3;
-			this.chkHotKey.Text = "Use a global hot key";
-			this.chkHotKey.UseVisualStyleBackColor = true;
-			this.chkHotKey.CheckedChanged += new System.EventHandler(this.chkHotKey_CheckedChanged);
-			// 
-			// numLimit
-			// 
-			this.numLimit.Location = new System.Drawing.Point(151, 19);
-			this.numLimit.Maximum = new decimal(new int[] {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(OptionsForm));
+            this.butCancel = new System.Windows.Forms.Button();
+            this.butSubmit = new System.Windows.Forms.Button();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.panHotKey = new System.Windows.Forms.Panel();
+            this.butHotKey = new System.Windows.Forms.Button();
+            this.txtHotKey = new System.Windows.Forms.TextBox();
+            this.chkHotKey = new System.Windows.Forms.CheckBox();
+            this.numLimit = new System.Windows.Forms.NumericUpDown();
+            this.chkTruncateTitle = new System.Windows.Forms.CheckBox();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.chkUpdates = new System.Windows.Forms.CheckBox();
+            this.chkWindowsAtEnd = new System.Windows.Forms.CheckBox();
+            this.groupBox1.SuspendLayout();
+            this.panHotKey.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numLimit)).BeginInit();
+            this.groupBox2.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // butCancel
+            // 
+            this.butCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.butCancel.Location = new System.Drawing.Point(287, 202);
+            this.butCancel.Name = "butCancel";
+            this.butCancel.Size = new System.Drawing.Size(85, 25);
+            this.butCancel.TabIndex = 2;
+            this.butCancel.Text = "Cancel";
+            this.butCancel.UseVisualStyleBackColor = true;
+            // 
+            // butSubmit
+            // 
+            this.butSubmit.Location = new System.Drawing.Point(196, 202);
+            this.butSubmit.Name = "butSubmit";
+            this.butSubmit.Size = new System.Drawing.Size(85, 25);
+            this.butSubmit.TabIndex = 1;
+            this.butSubmit.Text = "OK";
+            this.butSubmit.UseVisualStyleBackColor = true;
+            this.butSubmit.Click += new System.EventHandler(this.butSubmit_Click);
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.panHotKey);
+            this.groupBox1.Controls.Add(this.chkHotKey);
+            this.groupBox1.Controls.Add(this.numLimit);
+            this.groupBox1.Controls.Add(this.chkWindowsAtEnd);
+            this.groupBox1.Controls.Add(this.chkTruncateTitle);
+            this.groupBox1.Location = new System.Drawing.Point(12, 12);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(360, 109);
+            this.groupBox1.TabIndex = 3;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "General";
+            // 
+            // panHotKey
+            // 
+            this.panHotKey.Controls.Add(this.butHotKey);
+            this.panHotKey.Controls.Add(this.txtHotKey);
+            this.panHotKey.Location = new System.Drawing.Point(151, 45);
+            this.panHotKey.Name = "panHotKey";
+            this.panHotKey.Size = new System.Drawing.Size(203, 25);
+            this.panHotKey.TabIndex = 5;
+            // 
+            // butHotKey
+            // 
+            this.butHotKey.Location = new System.Drawing.Point(128, 1);
+            this.butHotKey.Name = "butHotKey";
+            this.butHotKey.Size = new System.Drawing.Size(75, 23);
+            this.butHotKey.TabIndex = 4;
+            this.butHotKey.Text = "Change";
+            this.butHotKey.UseVisualStyleBackColor = true;
+            this.butHotKey.Click += new System.EventHandler(this.butHotKey_Click);
+            // 
+            // txtHotKey
+            // 
+            this.txtHotKey.Location = new System.Drawing.Point(0, 3);
+            this.txtHotKey.Name = "txtHotKey";
+            this.txtHotKey.ReadOnly = true;
+            this.txtHotKey.Size = new System.Drawing.Size(122, 20);
+            this.txtHotKey.TabIndex = 2;
+            // 
+            // chkHotKey
+            // 
+            this.chkHotKey.AutoSize = true;
+            this.chkHotKey.Location = new System.Drawing.Point(6, 50);
+            this.chkHotKey.Name = "chkHotKey";
+            this.chkHotKey.Size = new System.Drawing.Size(123, 17);
+            this.chkHotKey.TabIndex = 3;
+            this.chkHotKey.Text = "Use a global hot key";
+            this.chkHotKey.UseVisualStyleBackColor = true;
+            this.chkHotKey.CheckedChanged += new System.EventHandler(this.chkHotKey_CheckedChanged);
+            // 
+            // numLimit
+            // 
+            this.numLimit.Location = new System.Drawing.Point(151, 19);
+            this.numLimit.Maximum = new decimal(new int[] {
             200,
             0,
             0,
             0});
-			this.numLimit.Minimum = new decimal(new int[] {
+            this.numLimit.Minimum = new decimal(new int[] {
             10,
             0,
             0,
             0});
-			this.numLimit.Name = "numLimit";
-			this.numLimit.Size = new System.Drawing.Size(90, 20);
-			this.numLimit.TabIndex = 1;
-			this.numLimit.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-			this.numLimit.Value = new decimal(new int[] {
+            this.numLimit.Name = "numLimit";
+            this.numLimit.Size = new System.Drawing.Size(90, 20);
+            this.numLimit.TabIndex = 1;
+            this.numLimit.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.numLimit.Value = new decimal(new int[] {
             50,
             0,
             0,
             0});
-			// 
-			// chkTruncateTitle
-			// 
-			this.chkTruncateTitle.AutoSize = true;
-			this.chkTruncateTitle.Location = new System.Drawing.Point(6, 20);
-			this.chkTruncateTitle.Name = "chkTruncateTitle";
-			this.chkTruncateTitle.Size = new System.Drawing.Size(132, 17);
-			this.chkTruncateTitle.TabIndex = 0;
-			this.chkTruncateTitle.Text = "Truncate window titles";
-			this.chkTruncateTitle.UseVisualStyleBackColor = true;
-			this.chkTruncateTitle.CheckedChanged += new System.EventHandler(this.chkTruncateTitle_CheckedChanged);
-			// 
-			// groupBox2
-			// 
-			this.groupBox2.Controls.Add(this.chkUpdates);
-			this.groupBox2.Location = new System.Drawing.Point(12, 126);
-			this.groupBox2.Name = "groupBox2";
-			this.groupBox2.Size = new System.Drawing.Size(360, 70);
-			this.groupBox2.TabIndex = 4;
-			this.groupBox2.TabStop = false;
-			this.groupBox2.Text = "Application";
-			// 
-			// chkUpdates
-			// 
-			this.chkUpdates.AutoSize = true;
-			this.chkUpdates.Location = new System.Drawing.Point(6, 19);
-			this.chkUpdates.Name = "chkUpdates";
-			this.chkUpdates.Size = new System.Drawing.Size(195, 17);
-			this.chkUpdates.TabIndex = 1;
-			this.chkUpdates.Text = "Always check for updates at startup";
-			this.chkUpdates.UseVisualStyleBackColor = true;
-			// 
-			// chkWindowsAtEnd
-			// 
-			this.chkWindowsAtEnd.AutoSize = true;
-			this.chkWindowsAtEnd.Location = new System.Drawing.Point(6, 80);
-			this.chkWindowsAtEnd.Name = "chkWindowsAtEnd";
-			this.chkWindowsAtEnd.Size = new System.Drawing.Size(163, 17);
-			this.chkWindowsAtEnd.TabIndex = 0;
-			this.chkWindowsAtEnd.Text = "Show windows list at the end";
-			this.chkWindowsAtEnd.UseVisualStyleBackColor = true;
-			this.chkWindowsAtEnd.CheckedChanged += new System.EventHandler(this.chkTruncateTitle_CheckedChanged);
-			// 
-			// OptionsForm
-			// 
-			this.AcceptButton = this.butSubmit;
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.CancelButton = this.butCancel;
-			this.ClientSize = new System.Drawing.Size(384, 239);
-			this.Controls.Add(this.groupBox2);
-			this.Controls.Add(this.groupBox1);
-			this.Controls.Add(this.butSubmit);
-			this.Controls.Add(this.butCancel);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.Name = "OptionsForm";
-			this.Text = "PinWin - Options";
-			this.TopMost = true;
-			this.groupBox1.ResumeLayout(false);
-			this.groupBox1.PerformLayout();
-			this.panHotKey.ResumeLayout(false);
-			this.panHotKey.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.numLimit)).EndInit();
-			this.groupBox2.ResumeLayout(false);
-			this.groupBox2.PerformLayout();
-			this.ResumeLayout(false);
+            // 
+            // chkTruncateTitle
+            // 
+            this.chkTruncateTitle.AutoSize = true;
+            this.chkTruncateTitle.Location = new System.Drawing.Point(6, 20);
+            this.chkTruncateTitle.Name = "chkTruncateTitle";
+            this.chkTruncateTitle.Size = new System.Drawing.Size(132, 17);
+            this.chkTruncateTitle.TabIndex = 0;
+            this.chkTruncateTitle.Text = "Truncate window titles";
+            this.chkTruncateTitle.UseVisualStyleBackColor = true;
+            this.chkTruncateTitle.CheckedChanged += new System.EventHandler(this.chkTruncateTitle_CheckedChanged);
+            // 
+            // groupBox2
+            // 
+            this.groupBox2.Controls.Add(this.chkUpdates);
+            this.groupBox2.Location = new System.Drawing.Point(12, 126);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(360, 70);
+            this.groupBox2.TabIndex = 4;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "Application";
+            // 
+            // chkUpdates
+            // 
+            this.chkUpdates.AutoSize = true;
+            this.chkUpdates.Location = new System.Drawing.Point(6, 19);
+            this.chkUpdates.Name = "chkUpdates";
+            this.chkUpdates.Size = new System.Drawing.Size(195, 17);
+            this.chkUpdates.TabIndex = 1;
+            this.chkUpdates.Text = "Always check for updates at startup";
+            this.chkUpdates.UseVisualStyleBackColor = true;
+            // 
+            // chkWindowsAtEnd
+            // 
+            this.chkWindowsAtEnd.AutoSize = true;
+            this.chkWindowsAtEnd.Location = new System.Drawing.Point(6, 80);
+            this.chkWindowsAtEnd.Name = "chkWindowsAtEnd";
+            this.chkWindowsAtEnd.Size = new System.Drawing.Size(163, 17);
+            this.chkWindowsAtEnd.TabIndex = 0;
+            this.chkWindowsAtEnd.Text = "Show windows list at the end";
+            this.chkWindowsAtEnd.UseVisualStyleBackColor = true;
+            this.chkWindowsAtEnd.CheckedChanged += new System.EventHandler(this.chkTruncateTitle_CheckedChanged);
+            // 
+            // OptionsForm
+            // 
+            this.AcceptButton = this.butSubmit;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.butCancel;
+            this.ClientSize = new System.Drawing.Size(384, 239);
+            this.Controls.Add(this.groupBox2);
+            this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.butSubmit);
+            this.Controls.Add(this.butCancel);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "OptionsForm";
+            this.Text = "PinWin - Options";
+            this.TopMost = true;
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            this.panHotKey.ResumeLayout(false);
+            this.panHotKey.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numLimit)).EndInit();
+            this.groupBox2.ResumeLayout(false);
+            this.groupBox2.PerformLayout();
+            this.ResumeLayout(false);
 
         }
 
@@ -225,6 +225,6 @@
         private System.Windows.Forms.CheckBox chkHotKey;
         private System.Windows.Forms.NumericUpDown numLimit;
         private System.Windows.Forms.CheckBox chkUpdates;
-		private System.Windows.Forms.CheckBox chkWindowsAtEnd;
-	}
+        private System.Windows.Forms.CheckBox chkWindowsAtEnd;
+    }
 }

--- a/PinWin/OptionsForm.cs
+++ b/PinWin/OptionsForm.cs
@@ -18,6 +18,7 @@ namespace PinWin
             // --- General section ---
             chkTruncateTitle.Checked = Settings.Default.TitleLengthLimit < int.MaxValue;
             numLimit.Value = Settings.Default.TitleLengthLimit;
+			chkWindowsAtEnd.Checked = Settings.Default.WindowsListAtEnd;
             chkHotKey.Checked = main.HotKey != null;
             panHotKey.Enabled = chkHotKey.Checked;
             txtHotKey.Text = selectedKeys.ToString();
@@ -57,6 +58,7 @@ namespace PinWin
             if (chkTruncateTitle.Checked)
                 Settings.Default.TitleLengthLimit = (int)numLimit.Value;
             else Settings.Default.TitleLengthLimit = int.MaxValue;
+			Settings.Default.WindowsListAtEnd = chkWindowsAtEnd.Checked;
             // --- Application section
             Settings.Default.AlwaysCheckForUpdates = chkUpdates.Checked;
             this.Close();

--- a/PinWin/OptionsForm.cs
+++ b/PinWin/OptionsForm.cs
@@ -18,7 +18,7 @@ namespace PinWin
             // --- General section ---
             chkTruncateTitle.Checked = Settings.Default.TitleLengthLimit < int.MaxValue;
             numLimit.Value = Settings.Default.TitleLengthLimit;
-			chkWindowsAtEnd.Checked = Settings.Default.WindowsListAtEnd;
+            chkWindowsAtEnd.Checked = Settings.Default.WindowsListAtEnd;
             chkHotKey.Checked = main.HotKey != null;
             panHotKey.Enabled = chkHotKey.Checked;
             txtHotKey.Text = selectedKeys.ToString();
@@ -58,7 +58,7 @@ namespace PinWin
             if (chkTruncateTitle.Checked)
                 Settings.Default.TitleLengthLimit = (int)numLimit.Value;
             else Settings.Default.TitleLengthLimit = int.MaxValue;
-			Settings.Default.WindowsListAtEnd = chkWindowsAtEnd.Checked;
+            Settings.Default.WindowsListAtEnd = chkWindowsAtEnd.Checked;
             // --- Application section
             Settings.Default.AlwaysCheckForUpdates = chkUpdates.Checked;
             this.Close();

--- a/PinWin/Properties/Settings.Designer.cs
+++ b/PinWin/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace PinWin.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.3.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -56,6 +56,18 @@ namespace PinWin.Properties {
             }
             set {
                 this["TitleLengthLimit"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool WindowsListAtEnd {
+            get {
+                return ((bool)(this["WindowsListAtEnd"]));
+            }
+            set {
+                this["WindowsListAtEnd"] = value;
             }
         }
     }

--- a/PinWin/Properties/Settings.settings
+++ b/PinWin/Properties/Settings.settings
@@ -11,5 +11,8 @@
     <Setting Name="TitleLengthLimit" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">50</Value>
     </Setting>
+    <Setting Name="WindowsListAtEnd" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
This commit adds an option to move the windows list in context menu to the end. In this case you can quickly enter "Select Window From Screen" mode just by doing "double click" (actually - click on icon, then click on the first context menu item) on PinWin icon.